### PR TITLE
Depend on rr_service

### DIFF
--- a/mbf_msgs/CMakeLists.txt
+++ b/mbf_msgs/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(catkin REQUIRED
   message_runtime
   nav_msgs
   std_msgs
+  rr_service
 )
 
 add_service_files(

--- a/mbf_msgs/package.xml
+++ b/mbf_msgs/package.xml
@@ -20,6 +20,7 @@
     <build_depend>genmsg</build_depend>
     <build_depend>message_runtime</build_depend>
     <build_depend>message_generation</build_depend>
+    <build_depend>rr_service</build_depend>
 
     <run_depend>std_msgs</run_depend>
     <run_depend>nav_msgs</run_depend>


### PR DESCRIPTION
Part of a series of PRs to convert service use to common version. Merge all PRs at the same time.

Necessary because of the dependency on forklift_interfaces messages