### PR TITLE
fix: main thread is blocked when canceling an execution

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
@@ -39,8 +39,6 @@
 #ifndef MBF_ABSTRACT_NAV__ABSTRACT_ACTION_BASE_H_
 #define MBF_ABSTRACT_NAV__ABSTRACT_ACTION_BASE_H_
 
-#include <boost/thread/detail/thread.hpp>
-#include <boost/thread/lock_types.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/lock_guard.hpp>
@@ -54,8 +52,6 @@
 
 #include <actionlib/server/action_server.h>
 #include <mbf_utility/robot_information.h>
-#include <ros/console.h>
-#include <ros/duration.h>
 
 #include "mbf_abstract_nav/MoveBaseFlexConfig.h"
 #include "mbf_abstract_nav/abstract_execution_base.h"

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
@@ -131,7 +131,6 @@ public:
       typename ConcurrencyMap::iterator slot_it = concurrency_slots_.find(slot);
       if (slot_it != concurrency_slots_.end() && slot_it->second.in_use) {
         // if there is already a plugin running on the same slot, cancel it
-        const auto current_state = slot_it->second.execution->getState();
         slot_it->second.execution->cancel();
 
         guard.unlock();

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
@@ -134,13 +134,11 @@ public:
         // if there is already a plugin running on the same slot, cancel it
         slot_it->second.execution->cancel();
 
-        guard.unlock();
         if (slot_it->second.thread_ptr->joinable())
         {
           cancel_execution_ = slot_it->second.execution;
           slot_it->second.thread_ptr->join();
         }
-        guard.lock();
       }
 
       if(slot_it != concurrency_slots_.end())

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_action_base.hpp
@@ -129,12 +129,14 @@ public:
     {
       boost::unique_lock<boost::mutex> guard(slot_map_mtx_);
       typename ConcurrencyMap::iterator slot_it = concurrency_slots_.find(slot);
-      if (slot_it != concurrency_slots_.end() && slot_it->second.in_use) {
+      if (slot_it != concurrency_slots_.end() && slot_it->second.in_use)
+      {
         // if there is already a plugin running on the same slot, cancel it
         slot_it->second.execution->cancel();
 
         guard.unlock();
-        if (slot_it->second.thread_ptr->joinable()) {
+        if (slot_it->second.thread_ptr->joinable())
+        {
           cancel_execution_ = slot_it->second.execution;
           slot_it->second.thread_ptr->join();
         }
@@ -163,17 +165,16 @@ public:
         threads_.create_thread(boost::bind(&AbstractActionBase::run, this, boost::ref(concurrency_slots_[slot])));
       }
 
-  virtual void start(
-      GoalHandle &goal_handle,
-      typename Execution::Ptr execution_ptr
-  )
+  virtual void start(GoalHandle &goal_handle, typename Execution::Ptr execution_ptr)
   {
     uint8_t slot = goal_handle.getGoal()->concurrency_slot;
-    if (cancel_future_.valid() && cancel_execution_) {
-      if (cancel_future_.wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
+    if (cancel_future_.valid() && cancel_execution_)
+    {
+      if (cancel_future_.wait_for(std::chrono::seconds(0)) != std::future_status::ready)
+      {
         cancel_execution_->stop();
-        }
       }
+    }
 
 
     if(goal_handle.getGoalStatus().status == actionlib_msgs::GoalStatus::RECALLING)

--- a/mbf_utility/src/odometry_helper.cpp
+++ b/mbf_utility/src/odometry_helper.cpp
@@ -47,7 +47,7 @@ OdometryHelper::OdometryHelper(const std::string& odom_topic)
 void OdometryHelper::odomCallback(const nav_msgs::Odometry::ConstPtr& msg)
 {
   ROS_INFO_STREAM_ONCE("Odometry received on topic " << getOdomTopic());
-  
+
   // we assume that the odometry is published in the frame of the base
   boost::mutex::scoped_lock lock(odom_mutex_);
   base_odom_ = *msg;

--- a/mbf_utility/src/odometry_helper.cpp
+++ b/mbf_utility/src/odometry_helper.cpp
@@ -47,9 +47,9 @@ OdometryHelper::OdometryHelper(const std::string& odom_topic)
 void OdometryHelper::odomCallback(const nav_msgs::Odometry::ConstPtr& msg)
 {
   ROS_INFO_STREAM_ONCE("Odometry received on topic " << getOdomTopic());
+  
   // we assume that the odometry is published in the frame of the base
   boost::mutex::scoped_lock lock(odom_mutex_);
-
   base_odom_ = *msg;
   if (base_odom_.header.stamp.isZero())
     base_odom_.header.stamp = ros::Time::now();

--- a/mbf_utility/src/odometry_helper.cpp
+++ b/mbf_utility/src/odometry_helper.cpp
@@ -35,6 +35,7 @@
  * Author: TKruse
  *********************************************************************/
 #include <mbf_utility/odometry_helper.h>
+#include "ros/console.h"
 
 namespace mbf_utility
 {
@@ -46,10 +47,10 @@ OdometryHelper::OdometryHelper(const std::string& odom_topic)
 
 void OdometryHelper::odomCallback(const nav_msgs::Odometry::ConstPtr& msg)
 {
-  ROS_INFO_STREAM_ONCE("Odometry received on topic " << getOdomTopic());
 
   // we assume that the odometry is published in the frame of the base
   boost::mutex::scoped_lock lock(odom_mutex_);
+  ROS_INFO_STREAM_THROTTLE(1,"odom callback");
   base_odom_ = *msg;
   if (base_odom_.header.stamp.isZero())
     base_odom_.header.stamp = ros::Time::now();

--- a/mbf_utility/src/odometry_helper.cpp
+++ b/mbf_utility/src/odometry_helper.cpp
@@ -35,7 +35,6 @@
  * Author: TKruse
  *********************************************************************/
 #include <mbf_utility/odometry_helper.h>
-#include "ros/console.h"
 
 namespace mbf_utility
 {
@@ -47,10 +46,10 @@ OdometryHelper::OdometryHelper(const std::string& odom_topic)
 
 void OdometryHelper::odomCallback(const nav_msgs::Odometry::ConstPtr& msg)
 {
-
+  ROS_INFO_STREAM_ONCE("Odometry received on topic " << getOdomTopic());
   // we assume that the odometry is published in the frame of the base
   boost::mutex::scoped_lock lock(odom_mutex_);
-  ROS_INFO_STREAM_THROTTLE(1,"odom callback");
+
   base_odom_ = *msg;
   if (base_odom_.header.stamp.isZero())
     base_odom_.header.stamp = ros::Time::now();


### PR DESCRIPTION
[AB#88671](https://dev.azure.com/rapyuta-robotics/flappter/_workitems/edit/88671)
When the cancel is implemented by the controller, it may take some time to cancel the goal. During this time, the main thread is blocked which causes the callbacks like odom callback to stop running. Controller relies on odom as a feedback to check if the robot is stopped before sending cancel, and this odom stops updating because the main thread is blocked. So there is a deadlock.
